### PR TITLE
STY more horizontal spacing on index

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -24,7 +24,7 @@
 
 <div class="container sk-landing-container pt-3 body" role="main">
   <div class="row no-gutters">
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="supervised_learning.html#supervised-learning"><h4 class="sk-card-title card-title">Classification</h4></a>
@@ -44,7 +44,7 @@
           <a href="auto_examples/index.html#classification" class="sk-btn-primary btn text-white btn-block" role="button">Examples</a>
       </div>
     </div>
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="supervised_learning.html#supervised-learning"><h4 class="sk-card-title card-title">Regression</h4></a>
@@ -64,7 +64,7 @@
           <a href="auto_examples/index.html#examples" class="sk-btn-primary btn text-white btn-block" role="button">Examples</a>
       </div>
     </div>
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="modules/clustering.html#clustering"><h4 class="sk-card-title card-title">Clustering</h4></a>
@@ -84,7 +84,7 @@
           <a href="auto_examples/index.html#cluster-examples" class="sk-btn-primary btn text-white btn-block" role="button">Examples</a>
       </div>
     </div>
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="modules/decomposition.html#decompositions"><h4 class="sk-card-title card-title">Dimensionality reduction</h4></a>
@@ -104,7 +104,7 @@
           <a href="auto_examples/index.html#decomposition-examples" class="sk-btn-primary btn text-white btn-block" role="button">Examples</a>
       </div>
     </div>
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="model_selection.html#model-selection"><h4 class="sk-card-title card-title">Model selection</h4></a>
@@ -124,7 +124,7 @@
           <a href="auto_examples/index.html#model-selection" class="sk-btn-primary btn text-white btn-block" role="button">Examples</a>
       </div>
     </div>
-    <div class="col-md-4 mb-3 px-md-2">
+    <div class="col-md-4 mb-3 px-md-2 index-box">
       <div class="card h-100">
         <div class="card-body">
           <a href="modules/preprocessing.html#preprocessing"><h4 class="sk-card-title card-title">Preprocessing</h4></a>

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -226,10 +226,6 @@ a.sk-nav-dropdown-item:active {
 /* LANDING PAGE STYLE */
 
 div.sk-landing-container {
-  max-width: 1240px;
-}
-
-div.sk-landing-container.body {
   max-width: 1400px;
 }
 
@@ -296,7 +292,7 @@ img.sk-footer-funding-logo {
 /* DOCS STYLE */
 
 .navbar > .sk-docs-container {
-  max-width: 1240px;
+  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -327,7 +323,7 @@ img.sk-footer-funding-logo {
 }
 
 #sk-doc-wrapper {
-  max-width: 1240px;
+  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -358,7 +354,7 @@ div.section h6 {
   cursor: pointer;
 }
 
-@media screen and (min-width: 1240px) {
+@media screen and (min-width: 1400px) {
   .sk-btn-toggle-toc {
     border-top-left-radius: 0.5rem;
   }
@@ -390,6 +386,9 @@ nav.sk-docs-navbar {
 
   #sk-page-content-wrapper {
     padding-left: 240px;
+    max-width: 1240px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   #sk-sidebar-wrapper {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -229,6 +229,16 @@ div.sk-landing-container {
   max-width: 1240px;
 }
 
+div.sk-landing-container.body {
+  max-width: 1400px;
+}
+
+div.index-box {
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 div.sk-landing-bg-more-info dd {
   padding-left: 0;
 }


### PR DESCRIPTION
Separate out the boxes on the landing page for wide screens

This just adds a bit of horizontal spaces on the landing page if the screen is large enough (screenshot below, sorry, I don't know why the carroussel image is not showing up):

![image](https://user-images.githubusercontent.com/208217/64490369-39b2f680-d22a-11e9-9294-9b142eaddb12.png)

Do not merge yet: another more invasive change is coming, and we can discuss which one is most desirable.
