### PR TITLE
STY: example download note to the right

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -810,6 +810,14 @@ div.sphx-glr-thumbcontainer {
   font-size: 0.9rem;
 }
 
+@media screen and (min-width: 1540px) {
+  .sphx-glr-download-link-note {
+    position: fixed;
+    right: 10pt;
+    width: 20ex;
+  }
+}
+
 /* rellinks */
 
 .sk-btn-rellink {


### PR DESCRIPTION
When the screen is large enough:

![image](https://user-images.githubusercontent.com/208217/64542818-397e2e00-d2f2-11e9-974b-7719e8052c39.png)
