### PR TITLE
Avoid images overflowing horizontally on small screens

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -799,6 +799,11 @@ div.body img.align-center {
   max-width: 800px;
 }
 
+div.body img {
+    max-width: 100%;
+    height: unset!important; /* Needed because sphinx sets the height */
+}
+
 img.align-center, .figure.align-center, object.align-center {
   display: block;
   margin-left: auto;


### PR DESCRIPTION
This is important for a page such as:
https://thomasjpfan.github.io/scikit-learn-website/modules/clustering.html

On a mobile phone it strongly overflows horizontally and the burger menu is no longer visible.