### PR TITLE
Pass known categories to the BinMapper

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
@@ -76,10 +76,4 @@ cdef void _map_num_col_to_bins(const X_DTYPE_C [:] data,
                 else:
                     left = middle + 1
 
-            if is_categorical and binning_thresholds[left] != data[i]:
-                # categorical data needs the values to match exactly. When they
-                # don't, then the category is considered missing. This happens
-                # when a category isn't seen during fit but seen at transform.
-                binned[i] = missing_values_bin_idx
-            else:
-                binned[i] = left
+            binned[i] = left

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -902,3 +902,30 @@ def test_categorical_bad_encoding_errors(Est):
            "<= 10")
     with pytest.raises(ValueError, match=msg):
         est.fit(X, y)
+
+
+@pytest.mark.parametrize('Est', (HistGradientBoostingClassifier,
+                                 HistGradientBoostingRegressor))
+def test_categorical_n_bins_errors(Est):
+    # test error when there is not enough bins or when values are >= n_bins
+
+    gb = Est(categorical_features=[True], max_bins=2)
+
+    X = np.array([[0, 1, 2]]).T
+    y = np.arange(3)
+    msg = ("Categorical feature at index 0 is expected to have a "
+           "cardinality <= 2")
+    with pytest.raises(ValueError, match=msg):
+        gb.fit(X, y)
+
+    X = np.array([[0, 2]]).T
+    y = np.arange(2)
+    msg = ("Categorical feature at index 0 is expected to be encoded with "
+           "values < 2")
+    with pytest.raises(ValueError, match=msg):
+        gb.fit(X, y)
+
+    # nans are ignored in the counts
+    X = np.array([[0, 1, np.nan]]).T
+    y = np.arange(3)
+    gb.fit(X, y)


### PR DESCRIPTION
Hey Thomas,

This PR passes the known categories from the Hist-GBDT estimator to the BinMapper, instead of letting the BinMapper figure it out.

I think this is preferable when there is some early stopping with a train/val split: we still want the BinMapper to know all the existing categories, not just those that are exclusive to the validation set. This is for the same reason that we allow users to pass a "categories" parameter to e.g. the OneHotEncoder.

One benefit is that we don't need `_find_bin_categories` categories anymore. There is also no risk of using `bin_mapper.transform` on unknown categories now.