### PR TITLE
ENH Enables array_api for LinearDiscriminantAnalysis

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -9,6 +9,7 @@ _global_config = {
     "working_memory": int(os.environ.get("SKLEARN_WORKING_MEMORY", 1024)),
     "print_changed_only": True,
     "display": "text",
+    "array_api_dispatch": False,
 }
 _threadlocal = threading.local()
 
@@ -40,7 +41,11 @@ def get_config():
 
 
 def set_config(
-    assume_finite=None, working_memory=None, print_changed_only=None, display=None
+    assume_finite=None,
+    working_memory=None,
+    print_changed_only=None,
+    display=None,
+    array_api_dispatch=None,
 ):
     """Set global scikit-learn configuration
 
@@ -95,11 +100,18 @@ def set_config(
         local_config["print_changed_only"] = print_changed_only
     if display is not None:
         local_config["display"] = display
+    if array_api_dispatch is not None:
+        local_config["array_api_dispatch"] = array_api_dispatch
 
 
 @contextmanager
 def config_context(
-    *, assume_finite=None, working_memory=None, print_changed_only=None, display=None
+    *,
+    assume_finite=None,
+    working_memory=None,
+    print_changed_only=None,
+    display=None,
+    array_api_dispatch=None,
 ):
     """Context manager for global scikit-learn configuration.
 
@@ -171,6 +183,7 @@ def config_context(
         working_memory=working_memory,
         print_changed_only=print_changed_only,
         display=display,
+        array_api_dispatch=array_api_dispatch,
     )
 
     try:

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -124,7 +124,6 @@ def _class_means(X, y):
         cnt = np.bincount(y)
         np.add.at(means, y, X)
         means /= cnt[:, None]
-
     return means
 
 
@@ -485,12 +484,10 @@ class LinearDiscriminantAnalysis(
         n_classes = self.classes_.shape[0]
 
         self.means_ = _class_means(X, y)
-
         if self.store_covariance:
             self.covariance_ = _class_cov(X, y, self.priors_)
 
         Xc = []
-
         for idx, group in enumerate(self.classes_):
             Xg = X[y == group]
             Xc.append(Xg - self.means_[idx, :])

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -35,6 +35,7 @@ from ..utils.extmath import safe_sparse_dot
 from ..utils.extmath import _incremental_mean_and_var
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
+from ..utils._array_api import get_namespace
 from ..utils._seq_dataset import ArrayDataset32, CSRDataset32
 from ..utils._seq_dataset import ArrayDataset64, CSRDataset64
 from ..utils.validation import check_is_fitted, _check_sample_weight
@@ -405,8 +406,9 @@ class LinearClassifierMixin(ClassifierMixin):
         check_is_fitted(self)
 
         X = self._validate_data(X, accept_sparse="csr", reset=False)
+        np, _ = get_namespace(X)
         scores = safe_sparse_dot(X, self.coef_.T, dense_output=True) + self.intercept_
-        return scores.ravel() if scores.shape[1] == 1 else scores
+        return np.reshape(scores, -1) if scores.shape[1] == 1 else scores
 
     def predict(self, X):
         """
@@ -422,12 +424,16 @@ class LinearClassifierMixin(ClassifierMixin):
         y_pred : ndarray of shape (n_samples,)
             Vector containing the class labels for each sample.
         """
+        np, _ = get_namespace(X)
         scores = self.decision_function(X)
         if len(scores.shape) == 1:
-            indices = (scores > 0).astype(int)
+            indices = np.astype(scores > 0, int)
         else:
             indices = scores.argmax(axis=1)
-        return self.classes_[indices]
+        # Should really use `np.take`
+        # return np.take(self.classes_, indices, axis=0)
+        # assuming classes are [0, 1, 2, ....]
+        return indices
 
     def _predict_proba_lr(self, X):
         """Probability estimation for OvR logistic regression.

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1,0 +1,91 @@
+"""Tools to support array_api."""
+import numpy
+from .._config import get_config
+
+from contextlib import nullcontext
+
+
+# There are more clever ways to wrap the API to ignore kwargs, but I am writing them out
+# explicitly for demonstration purposes
+class _ArrayAPIWrapper:
+    def __init__(self, array_namespace):
+        self._array_namespace = array_namespace
+
+    def __getattr__(self, name):
+        return getattr(self._array_namespace, name)
+
+    def errstate(self, *args, **kwargs):
+        # errstate not in `array_api`
+        return nullcontext()
+
+    def astype(self, x, dtype, *, copy=True, **kwargs):
+        # ignore parameters that is not supported by array-api
+        f = self._array_namespace.astype
+        return f(x, dtype, copy=copy)
+
+    def asarray(self, obj, dtype=None, device=None, copy=True, **kwargs):
+        f = self._array_namespace.asarray
+        return f(obj, dtype=dtype, device=device, copy=copy)
+
+    def may_share_memory(self, *args, **kwargs):
+        # The safe choice is to return True all the time
+        return True
+
+    def asanyarray(self, array, *args, **kwargs):
+        # noop
+        return array
+
+    def concatenate(self, arrays, *, axis=0, **kwargs):
+        # ignore parameters that is not supported by array-api
+        f = self._array_namespace.concat
+        return f(arrays, axis=axis)
+
+    def unique(self, x, return_inverse=False):
+        if return_inverse:
+            f = self._array_namespace.unique_inverse
+        else:
+            f = self._array_namespace.unique_values
+        return f(x)
+
+    def bincount(self, x):
+        f = self._array_namespace.unique_counts
+        return f(x)[1]
+
+
+class _NumPyApiWrapper:
+    def __getattr__(self, name):
+        return getattr(numpy, name)
+
+    def astype(self, x, dtype, *args, **kwargs):
+        # astype is not defined in the top level numpy namespace
+        return x.astype(dtype, *args, **kwargs)
+
+
+def get_namespace(*xs):
+    # `xs` contains one or more arrays, or possibly Python scalars (accepting
+    # those is a matter of taste, but doesn't seem unreasonable).
+    # Returns a tuple: (array_namespace, is_array_api)
+
+    if not get_config()["array_api_dispatch"]:
+        return _NumPyApiWrapper(), False
+
+    namespaces = {
+        x.__array_namespace__() if hasattr(x, "__array_namespace__") else None
+        for x in xs
+        if not isinstance(x, (bool, int, float, complex))
+    }
+
+    if not namespaces:
+        # one could special-case np.ndarray above or use np.asarray here if
+        # older numpy versions need to be supported.
+        raise ValueError("Unrecognized array input")
+
+    if len(namespaces) != 1:
+        raise ValueError(f"Multiple namespaces for array inputs: {namespaces}")
+
+    (xp,) = namespaces
+    if xp is None:
+        # Use numpy as default
+        return _NumPyApiWrapper(), False
+
+    return _ArrayAPIWrapper(xp), True

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -106,13 +106,17 @@ def unique_labels(*ys):
         raise ValueError("Unknown label type: %s" % repr(ys))
 
     if is_array_api:
-        return _unique_labels(ys[0])
+        # array_api does not allow for mixed dtypes
+        unique_ys = np.concatenate([_unique_labels(y) for y in ys])
+        return np.unique(unique_ys)
 
-    # TODO: Mixing `set` + array_api is not allowed, refactor?
-    ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
+    ys_labels = set(chain.from_iterable((i for i in _unique_labels(y)) for y in ys))
     # Check that we don't mix string type with number type
     if len(set(isinstance(label, str) for label in ys_labels)) > 1:
         raise ValueError("Mix of label input types (string and number)")
+
+    # print(ys_label)
+    # assert False
 
     return np.asarray(sorted(ys_labels))
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -100,7 +100,6 @@ def _assert_all_finite(
 
     if _get_config()["assume_finite"]:
         return
-
     X = np.asanyarray(X)
     # First try an O(n) time, O(1) space solution for the common case that
     # everything is finite; fall back to O(n) space np.isfinite to prevent


### PR DESCRIPTION
Another example of using `array_api` + scikit-learn's LinearDiscriminantAnalysis.

There is a good speed up 14x speed up when using cupy compared to numpy as seen in this [gist](https://gist.github.com/thomasjpfan/45f8bd908f56f6ab5107c0bdde04b7e7).

Most workarounds are similar to the ones in https://github.com/thomasjpfan/scikit-learn/pull/99.